### PR TITLE
fix: harden JWT validation and refresh token rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ After having successfully authenticated with `Authenticator`, created the jwt to
 
 PROVIDED: `MiddlewareFunc`
 
-This is gin middleware that should be used within any endpoints that require the jwt token to be present. This middleware will parse the request headers for the token if it exists, and check that the jwt token is valid (not expired, correct signature). Then it will call `IdentityHandler` followed by `Authorizator`. If `Authorizator` passes and all of the previous token validity checks passed, the middleware will continue the request. If any of these checks fail, the `Unauthorized` function is used (explained below).
+This is gin middleware that should be used within any endpoints that require the jwt token to be present. This middleware will parse the request headers for the token if it exists, and check that the jwt token is valid (expected signing method, correct signature, and valid time-based claims such as `exp` and `nbf`). Then it will call `IdentityHandler` followed by `Authorizator`. If `Authorizator` passes and all of the previous token validity checks passed, the middleware will continue the request. If any of these checks fail, the `Unauthorized` function is used (explained below).
 
 OPTIONAL: `IdentityHandler`
 
@@ -356,7 +356,7 @@ This should likely just return back to the user the http status code, if logout 
 
 PROVIDED: `RefreshHandler`:
 
-This is a provided function to be called on any refresh token endpoint. If the token passed in is was issued within the `MaxRefreshTime` time frame, then this handler will create/set a new token similar to the `LoginHandler`, and pass this token into `RefreshResponse`
+This is a provided function to be called on any refresh token endpoint. If the refresh token exists in the configured `TokenStore` and has not expired, this handler will consume it, mint a fresh access token and refresh token pair, and pass the new pair into `RefreshResponse`. Refresh tokens are single-use when the in-memory store is used.
 
 OPTIONAL: `RefreshResponse`:
 

--- a/auth_jwt.go
+++ b/auth_jwt.go
@@ -6,7 +6,6 @@ import (
 	"crypto/rsa"
 	"encoding/base64"
 	"errors"
-	"fmt"
 	"net/http"
 	"os"
 	"strings"
@@ -86,6 +85,7 @@ var (
 	ErrMissingAuthenticatorFunc = errors.New("authenticator function is missing")
 	ErrMissingExpField          = errors.New("missing exp field")
 	ErrWrongFormatOfExp         = errors.New("wrong format of exp field")
+	ErrInvalidToken             = errors.New("invalid token")
 	ErrInvalidSigningAlgorithm  = errors.New("invalid signing algorithm")
 	ErrNoPrivKeyFile            = errors.New("private key file is missing")
 	ErrNoPubKeyFile             = errors.New("public key file is missing")
@@ -103,10 +103,6 @@ var (
 	ErrTokenNotValidYet         = errors.New("token is not valid yet")
 	ErrMissingRefreshToken      = errors.New("refresh token is missing")
 )
-
-type refreshTokenConsumer interface {
-	Consume(ctx context.Context, token string) (any, error)
-}
 
 type refreshTokenRotator interface {
 	Rotate(ctx context.Context, oldToken, newToken string, userData any, expiry time.Time) error
@@ -524,7 +520,6 @@ func (mw *ToukaJWTMiddleware) ParseToken(c *touka.Context) (*jwt.Token, error) {
 		if mw.KeyFunc != nil {
 			return mw.KeyFunc(t)
 		}
-		c.Set("JWT_TOKEN", token)
 		if mw.usingPublicKeyAlgo() {
 			return mw.pubKey, nil
 		}
@@ -534,8 +529,9 @@ func (mw *ToukaJWTMiddleware) ParseToken(c *touka.Context) (*jwt.Token, error) {
 		return nil, err
 	}
 	if !parsedToken.Valid {
-		return nil, fmt.Errorf("invalid token")
+		return nil, ErrInvalidToken
 	}
+	c.Set("JWT_TOKEN", token)
 	return parsedToken, nil
 }
 

--- a/auth_jwt.go
+++ b/auth_jwt.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rsa"
 	"encoding/base64"
 	"errors"
+	"fmt"
 	"net/http"
 	"os"
 	"strings"
@@ -99,8 +100,17 @@ var (
 	ErrMissingLoginValues       = errors.New("missing Username or Password")
 	ErrFailedTokenCreation      = errors.New("failed to create token")
 	ErrExpiredToken             = errors.New("token is expired")
+	ErrTokenNotValidYet         = errors.New("token is not valid yet")
 	ErrMissingRefreshToken      = errors.New("refresh token is missing")
 )
+
+type refreshTokenConsumer interface {
+	Consume(ctx context.Context, token string) (any, error)
+}
+
+type refreshTokenRotator interface {
+	Rotate(ctx context.Context, oldToken, newToken string, userData any, expiry time.Time) error
+}
 
 func New(mw *ToukaJWTMiddleware) (*ToukaJWTMiddleware, error) {
 	if err := mw.MiddlewareInit(); err != nil {
@@ -140,9 +150,12 @@ func (mw *ToukaJWTMiddleware) MiddlewareInit() error {
 	if mw.RefreshTokenCookieName == "" {
 		mw.RefreshTokenCookieName = "refresh_token"
 	}
-	// Refresh token cookie security defaults to true for enhanced security
-	mw.RefreshTokenSecureCookie = true
-	mw.RefreshTokenCookieHTTPOnly = true
+	if !mw.RefreshTokenSecureCookie {
+		mw.RefreshTokenSecureCookie = mw.SecureCookie
+	}
+	if !mw.RefreshTokenCookieHTTPOnly {
+		mw.RefreshTokenCookieHTTPOnly = mw.CookieHTTPOnly
+	}
 	if mw.RefreshTokenTimeout == 0 {
 		if mw.MaxRefresh != 0 {
 			mw.RefreshTokenTimeout = mw.MaxRefresh
@@ -367,17 +380,33 @@ func (mw *ToukaJWTMiddleware) RefreshHandler(c *touka.Context) {
 		mw.unauthorized(c, http.StatusBadRequest, mw.HTTPStatusMessageFunc(ErrMissingRefreshToken, c))
 		return
 	}
-	userData, err := mw.TokenStore.Get(c.Request.Context(), refreshToken)
+	ctx := c.Request.Context()
+	var (
+		userData any
+		err      error
+	)
+	userData, err = mw.TokenStore.Get(ctx, refreshToken)
 	if err != nil {
 		mw.unauthorized(c, http.StatusUnauthorized, mw.HTTPStatusMessageFunc(err, c))
 		return
 	}
-	tokenPair, err := mw.TokenGenerator(c.Request.Context(), userData)
+	tokenPair, err := mw.generateTokenPair(ctx, userData, false)
 	if err != nil {
 		mw.unauthorized(c, http.StatusInternalServerError, mw.HTTPStatusMessageFunc(err, c))
 		return
 	}
-	if err := mw.TokenStore.Delete(c.Request.Context(), refreshToken); err != nil {
+	if rotator, ok := mw.TokenStore.(refreshTokenRotator); ok {
+		err = rotator.Rotate(ctx, refreshToken, tokenPair.RefreshToken, userData, time.Unix(tokenPair.CreatedAt, 0).Add(mw.RefreshTokenTimeout))
+	} else {
+		err = mw.TokenStore.Set(ctx, tokenPair.RefreshToken, userData, time.Unix(tokenPair.CreatedAt, 0).Add(mw.RefreshTokenTimeout))
+		if err == nil {
+			err = mw.TokenStore.Delete(ctx, refreshToken)
+			if err != nil {
+				_ = mw.TokenStore.Delete(ctx, tokenPair.RefreshToken)
+			}
+		}
+	}
+	if err != nil {
 		mw.unauthorized(c, http.StatusInternalServerError, mw.HTTPStatusMessageFunc(err, c))
 		return
 	}
@@ -387,16 +416,23 @@ func (mw *ToukaJWTMiddleware) RefreshHandler(c *touka.Context) {
 }
 
 func (mw *ToukaJWTMiddleware) TokenGenerator(ctx context.Context, data any) (*core.Token, error) {
+	return mw.generateTokenPair(ctx, data, true)
+}
+
+func (mw *ToukaJWTMiddleware) generateTokenPair(ctx context.Context, data any, persistRefreshToken bool) (*core.Token, error) {
 	token := jwt.New(jwt.GetSigningMethod(mw.SigningAlgorithm))
+	token.Header["typ"] = "JWT"
 	claims := token.Claims.(jwt.MapClaims)
 	if mw.PayloadFunc != nil {
 		for k, v := range mw.PayloadFunc(data) {
 			claims[k] = v
 		}
 	}
-	expire := mw.TimeFunc().Add(mw.TimeoutFunc(data))
+	now := mw.TimeFunc()
+	expire := now.Add(mw.TimeoutFunc(data))
 	claims[mw.ExpField] = expire.Unix()
-	claims["orig_iat"] = mw.TimeFunc().Unix()
+	claims["iat"] = now.Unix()
+	claims["orig_iat"] = now.Unix()
 	accessToken, err := mw.signedString(token)
 	if err != nil {
 		return nil, err
@@ -407,16 +443,19 @@ func (mw *ToukaJWTMiddleware) TokenGenerator(ctx context.Context, data any) (*co
 		return nil, err
 	}
 
-	err = mw.TokenStore.Set(ctx, refreshToken, data, mw.TimeFunc().Add(mw.RefreshTokenTimeout))
-	if err != nil {
-		return nil, err
+	refreshExpiry := now.Add(mw.RefreshTokenTimeout)
+	if persistRefreshToken {
+		err = mw.TokenStore.Set(ctx, refreshToken, data, refreshExpiry)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return &core.Token{
 		AccessToken:  accessToken,
 		RefreshToken: refreshToken,
 		ExpiresAt:    expire.Unix(),
-		CreatedAt:    mw.TimeFunc().Unix(),
+		CreatedAt:    now.Unix(),
 		TokenType:    "Bearer",
 	}, nil
 }
@@ -426,7 +465,7 @@ func (mw *ToukaJWTMiddleware) generateRefreshToken() (string, error) {
 	if _, err := rand.Read(token); err != nil {
 		return "", err
 	}
-	return base64.URLEncoding.EncodeToString(token), nil
+	return base64.RawURLEncoding.EncodeToString(token), nil
 }
 
 func (mw *ToukaJWTMiddleware) extractRefreshToken(c *touka.Context) string {
@@ -457,6 +496,9 @@ func (mw *ToukaJWTMiddleware) ParseToken(c *touka.Context) (*jwt.Token, error) {
 			break
 		}
 		parts := strings.Split(strings.TrimSpace(method), ":")
+		if len(parts) != 2 {
+			continue
+		}
 		k, v := strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1])
 		switch k {
 		case "header":
@@ -474,19 +516,38 @@ func (mw *ToukaJWTMiddleware) ParseToken(c *touka.Context) (*jwt.Token, error) {
 	if token == "" {
 		return nil, ErrEmptyAuthHeader
 	}
-	return jwt.Parse(token, func(t *jwt.Token) (any, error) {
+	parseOptions := mw.buildParseOptions()
+	parsedToken, err := jwt.Parse(token, func(t *jwt.Token) (any, error) {
 		if jwt.GetSigningMethod(mw.SigningAlgorithm) != t.Method {
 			return nil, ErrInvalidSigningAlgorithm
 		}
 		if mw.KeyFunc != nil {
 			return mw.KeyFunc(t)
 		}
+		c.Set("JWT_TOKEN", token)
 		if mw.usingPublicKeyAlgo() {
 			return mw.pubKey, nil
 		}
-		c.Set("JWT_TOKEN", token)
 		return mw.Key, nil
-	}, mw.ParseOptions...)
+	}, parseOptions...)
+	if err != nil {
+		return nil, err
+	}
+	if !parsedToken.Valid {
+		return nil, fmt.Errorf("invalid token")
+	}
+	return parsedToken, nil
+}
+
+func (mw *ToukaJWTMiddleware) buildParseOptions() []jwt.ParserOption {
+	baseOptions := []jwt.ParserOption{
+		jwt.WithValidMethods([]string{mw.SigningAlgorithm}),
+		jwt.WithTimeFunc(mw.TimeFunc),
+	}
+	if mw.ExpField == "exp" {
+		baseOptions = append(baseOptions, jwt.WithExpirationRequired())
+	}
+	return append(baseOptions, mw.ParseOptions...)
 }
 
 func (mw *ToukaJWTMiddleware) jwtFromHeader(c *touka.Context, key string) string {
@@ -505,6 +566,8 @@ func (mw *ToukaJWTMiddleware) handleTokenError(c *touka.Context, err error) {
 	switch {
 	case errors.Is(err, jwt.ErrTokenExpired):
 		mw.unauthorized(c, http.StatusUnauthorized, mw.HTTPStatusMessageFunc(ErrExpiredToken, c))
+	case errors.Is(err, jwt.ErrTokenNotValidYet):
+		mw.unauthorized(c, http.StatusUnauthorized, mw.HTTPStatusMessageFunc(ErrTokenNotValidYet, c))
 	default:
 		mw.unauthorized(c, http.StatusUnauthorized, mw.HTTPStatusMessageFunc(err, c))
 	}

--- a/auth_jwt.go
+++ b/auth_jwt.go
@@ -391,10 +391,11 @@ func (mw *ToukaJWTMiddleware) RefreshHandler(c *touka.Context) {
 		mw.unauthorized(c, http.StatusInternalServerError, mw.HTTPStatusMessageFunc(err, c))
 		return
 	}
+	refreshExpiry := time.Unix(tokenPair.CreatedAt, 0).Add(mw.RefreshTokenTimeout)
 	if rotator, ok := mw.TokenStore.(refreshTokenRotator); ok {
-		err = rotator.Rotate(ctx, refreshToken, tokenPair.RefreshToken, userData, time.Unix(tokenPair.CreatedAt, 0).Add(mw.RefreshTokenTimeout))
+		err = rotator.Rotate(ctx, refreshToken, tokenPair.RefreshToken, userData, refreshExpiry)
 	} else {
-		err = mw.TokenStore.Set(ctx, tokenPair.RefreshToken, userData, time.Unix(tokenPair.CreatedAt, 0).Add(mw.RefreshTokenTimeout))
+		err = mw.TokenStore.Set(ctx, tokenPair.RefreshToken, userData, refreshExpiry)
 		if err == nil {
 			err = mw.TokenStore.Delete(ctx, refreshToken)
 			if err != nil {

--- a/auth_jwt_test.go
+++ b/auth_jwt_test.go
@@ -1,17 +1,21 @@
 package jwt
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/appleboy/gofight/v2"
+	"github.com/fenthope/jwt/store"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/infinite-iroha/touka"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
 )
 
@@ -30,13 +34,30 @@ var (
 	}
 )
 
+type failingRotateStore struct {
+	*store.InMemoryRefreshTokenStore
+}
+
+func (s *failingRotateStore) Rotate(ctx context.Context, oldToken, newToken string, userData any, expiry time.Time) error {
+	return errors.New("rotate failed")
+}
+
 func makeTokenString(username string) string {
 	token := jwt.New(jwt.SigningMethodHS256)
 	claims := token.Claims.(jwt.MapClaims)
 	claims["identity"] = username
 	claims["exp"] = time.Now().Add(time.Hour).Unix()
+	claims["iat"] = time.Now().Unix()
 	claims["orig_iat"] = time.Now().Unix()
 	s, _ := token.SignedString(key)
+	return s
+}
+
+func makeTokenWithClaims(t *testing.T, claims jwt.MapClaims) string {
+	t.Helper()
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	s, err := token.SignedString(key)
+	require.NoError(t, err)
 	return s
 }
 
@@ -138,6 +159,19 @@ func TestSetCookie(t *testing.T) {
 	assert.Equal(t, "jwt", cookies[0].Name)
 }
 
+func TestRefreshCookieDefaultsFollowAccessCookieSettings(t *testing.T) {
+	defaultMW, err := New(&ToukaJWTMiddleware{
+		Realm:          "test",
+		Key:            key,
+		SendCookie:     true,
+		SecureCookie:   true,
+		CookieHTTPOnly: true,
+	})
+	require.NoError(t, err)
+	assert.True(t, defaultMW.RefreshTokenSecureCookie)
+	assert.True(t, defaultMW.RefreshTokenCookieHTTPOnly)
+}
+
 func TestMissingAuthenticator(t *testing.T) {
 	mw, _ := New(&ToukaJWTMiddleware{Realm: "test", Key: key})
 	handler := toukaHandler(mw)
@@ -191,6 +225,125 @@ func TestExpiredToken(t *testing.T) {
 			assert.Equal(t, 401, r.Code)
 			assert.Contains(t, r.Body.String(), "token is expired")
 		})
+}
+
+func TestTokenGeneratorAddsStandardIssuedAt(t *testing.T) {
+	now := time.Unix(1700000000, 0)
+	auth, err := New(&ToukaJWTMiddleware{
+		Realm:    "test",
+		Key:      key,
+		TimeFunc: func() time.Time { return now },
+	})
+	require.NoError(t, err)
+
+	tokenPair, err := auth.TokenGenerator(context.Background(), "admin")
+	require.NoError(t, err)
+
+	parsed, err := jwt.Parse(tokenPair.AccessToken, func(token *jwt.Token) (any, error) {
+		return key, nil
+	}, jwt.WithTimeFunc(func() time.Time { return now }))
+	require.NoError(t, err)
+	claims := parsed.Claims.(jwt.MapClaims)
+	assert.Equal(t, float64(now.Unix()), claims["iat"])
+	assert.Equal(t, float64(now.Unix()), claims["orig_iat"])
+}
+
+func TestMiddlewareRejectsTokenWithoutExpByDefault(t *testing.T) {
+	auth, err := New(&ToukaJWTMiddleware{
+		Realm: "test",
+		Key:   key,
+	})
+	require.NoError(t, err)
+	handler := toukaHandler(auth)
+	r := gofight.New()
+
+	token := makeTokenWithClaims(t, jwt.MapClaims{
+		"identity": "admin",
+		"iat":      time.Now().Unix(),
+	})
+
+	r.GET("/auth/hello").SetHeader(gofight.H{"Authorization": "Bearer " + token}).
+		Run(handler, func(r gofight.HTTPResponse, rq gofight.HTTPRequest) {
+			assert.Equal(t, http.StatusUnauthorized, r.Code)
+		})
+}
+
+func TestMiddlewareRejectsTokenNotValidYet(t *testing.T) {
+	auth, err := New(&ToukaJWTMiddleware{
+		Realm: "test",
+		Key:   key,
+	})
+	require.NoError(t, err)
+	handler := toukaHandler(auth)
+	r := gofight.New()
+
+	token := makeTokenWithClaims(t, jwt.MapClaims{
+		"identity": "admin",
+		"exp":      time.Now().Add(time.Hour).Unix(),
+		"nbf":      time.Now().Add(time.Hour).Unix(),
+		"iat":      time.Now().Unix(),
+	})
+
+	r.GET("/auth/hello").SetHeader(gofight.H{"Authorization": "Bearer " + token}).
+		Run(handler, func(r gofight.HTTPResponse, rq gofight.HTTPRequest) {
+			assert.Equal(t, http.StatusUnauthorized, r.Code)
+			assert.Contains(t, r.Body.String(), "token is not valid yet")
+		})
+}
+
+func TestRefreshTokenRotateSucceedsOnceInMemoryStore(t *testing.T) {
+	s := store.NewInMemoryRefreshTokenStore()
+	err := s.Set(context.Background(), "refresh-token", "admin", time.Now().Add(time.Hour))
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	results := make(chan error, 2)
+	for range 2 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			err := s.Rotate(context.Background(), "refresh-token", makeTokenString("next"), "admin", time.Now().Add(time.Hour))
+			results <- err
+		}()
+	}
+	wg.Wait()
+	close(results)
+
+	var okCount, notFoundCount int
+	for err := range results {
+		if err == nil {
+			okCount++
+			continue
+		}
+		if errors.Is(err, store.ErrRefreshTokenNotFound) {
+			notFoundCount++
+		}
+	}
+	assert.Equal(t, 1, okCount)
+	assert.Equal(t, 1, notFoundCount)
+}
+
+func TestRefreshHandlerPreservesOldTokenWhenRotationFails(t *testing.T) {
+	tokenStore := &failingRotateStore{InMemoryRefreshTokenStore: store.NewInMemoryRefreshTokenStore()}
+	err := tokenStore.Set(context.Background(), "refresh-token", "admin", time.Now().Add(time.Hour))
+	require.NoError(t, err)
+
+	auth, err := New(&ToukaJWTMiddleware{
+		Realm:      "test",
+		Key:        key,
+		TokenStore: tokenStore,
+	})
+	require.NoError(t, err)
+
+	handler := toukaHandler(auth)
+	r := gofight.New()
+	r.GET("/refresh?refresh_token=refresh-token").Run(handler, func(r gofight.HTTPResponse, rq gofight.HTTPRequest) {
+		assert.Equal(t, http.StatusInternalServerError, r.Code)
+	})
+
+	userData, err := tokenStore.Get(context.Background(), "refresh-token")
+	require.NoError(t, err)
+	assert.Equal(t, "admin", userData)
 }
 
 func TestHTTPStatusMessageFunc(t *testing.T) {

--- a/auth_jwt_test.go
+++ b/auth_jwt_test.go
@@ -291,6 +291,31 @@ func TestMiddlewareRejectsTokenNotValidYet(t *testing.T) {
 		})
 }
 
+func TestParseTokenDoesNotSetContextTokenForInvalidSignature(t *testing.T) {
+	auth, err := New(&ToukaJWTMiddleware{
+		Realm: "test",
+		Key:   key,
+	})
+	require.NoError(t, err)
+
+	wrongKeyToken := jwt.New(jwt.SigningMethodHS256)
+	claims := wrongKeyToken.Claims.(jwt.MapClaims)
+	claims["identity"] = "admin"
+	claims["exp"] = time.Now().Add(time.Hour).Unix()
+	signed, err := wrongKeyToken.SignedString([]byte("wrong-secret"))
+	require.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	c, _ := touka.CreateTestContext(w)
+	req := httptest.NewRequest(http.MethodGet, "/auth/hello", nil)
+	req.Header.Set("Authorization", "Bearer "+signed)
+	c.Request = req
+
+	_, err = auth.ParseToken(c)
+	require.Error(t, err)
+	assert.Empty(t, GetToken(c))
+}
+
 func TestRefreshTokenRotateSucceedsOnceInMemoryStore(t *testing.T) {
 	s := store.NewInMemoryRefreshTokenStore()
 	err := s.Set(context.Background(), "refresh-token", "admin", time.Now().Add(time.Hour))
@@ -321,6 +346,26 @@ func TestRefreshTokenRotateSucceedsOnceInMemoryStore(t *testing.T) {
 	}
 	assert.Equal(t, 1, okCount)
 	assert.Equal(t, 1, notFoundCount)
+}
+
+func TestInMemoryRefreshTokenStoreCountPurgesExpiredTokens(t *testing.T) {
+	s := store.NewInMemoryRefreshTokenStore()
+	err := s.Set(context.Background(), "expired-token", "admin", time.Now().Add(-time.Second))
+	require.NoError(t, err)
+	err = s.Set(context.Background(), "active-token", "admin", time.Now().Add(time.Hour))
+	require.NoError(t, err)
+
+	count, err := s.Count(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+
+	_, err = s.Get(context.Background(), "expired-token")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, store.ErrRefreshTokenNotFound) || errors.Is(err, store.ErrRefreshTokenExpired))
+
+	userData, err := s.Get(context.Background(), "active-token")
+	require.NoError(t, err)
+	assert.Equal(t, "admin", userData)
 }
 
 func TestRefreshHandlerPreservesOldTokenWhenRotationFails(t *testing.T) {

--- a/auth_jwt_test.go
+++ b/auth_jwt_test.go
@@ -348,6 +348,23 @@ func TestRefreshTokenRotateSucceedsOnceInMemoryStore(t *testing.T) {
 	assert.Equal(t, 1, notFoundCount)
 }
 
+func TestRefreshTokenRotateSupportsSameOldAndNewToken(t *testing.T) {
+	s := store.NewInMemoryRefreshTokenStore()
+	err := s.Set(context.Background(), "refresh-token", "admin", time.Now().Add(time.Hour))
+	require.NoError(t, err)
+
+	err = s.Rotate(context.Background(), "refresh-token", "refresh-token", "admin", time.Now().Add(2*time.Hour))
+	require.NoError(t, err)
+
+	userData, err := s.Get(context.Background(), "refresh-token")
+	require.NoError(t, err)
+	assert.Equal(t, "admin", userData)
+
+	count, err := s.Count(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 1, count)
+}
+
 func TestInMemoryRefreshTokenStoreCountPurgesExpiredTokens(t *testing.T) {
 	s := store.NewInMemoryRefreshTokenStore()
 	err := s.Set(context.Background(), "expired-token", "admin", time.Now().Add(-time.Second))

--- a/store/memory.go
+++ b/store/memory.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"container/heap"
 	"context"
 	"errors"
 	"sync"
@@ -11,40 +12,109 @@ import (
 
 var _ core.TokenStore = &InMemoryRefreshTokenStore{}
 
-type InMemoryRefreshTokenStore struct {
-	tokens map[string]*core.RefreshTokenData
-	mu     sync.RWMutex
+type expiryEntry struct {
+	token  string
+	expiry time.Time
+	index  int
 }
 
-func (s *InMemoryRefreshTokenStore) cleanupExpiredLocked(now time.Time) int {
+type expiryHeap []*expiryEntry
+
+func (h expiryHeap) Len() int { return len(h) }
+
+func (h expiryHeap) Less(i, j int) bool {
+	return h[i].expiry.Before(h[j].expiry)
+}
+
+func (h expiryHeap) Swap(i, j int) {
+	h[i], h[j] = h[j], h[i]
+	h[i].index = i
+	h[j].index = j
+}
+
+func (h *expiryHeap) Push(x any) {
+	entry := x.(*expiryEntry)
+	entry.index = len(*h)
+	*h = append(*h, entry)
+}
+
+func (h *expiryHeap) Pop() any {
+	old := *h
+	n := len(old)
+	entry := old[n-1]
+	old[n-1] = nil
+	entry.index = -1
+	*h = old[:n-1]
+	return entry
+}
+
+type InMemoryRefreshTokenStore struct {
+	tokens   map[string]*core.RefreshTokenData
+	expiryIx map[string]*expiryEntry
+	expiries expiryHeap
+	mu       sync.RWMutex
+}
+
+func NewInMemoryRefreshTokenStore() *InMemoryRefreshTokenStore {
+	s := &InMemoryRefreshTokenStore{
+		tokens:   make(map[string]*core.RefreshTokenData),
+		expiryIx: make(map[string]*expiryEntry),
+	}
+	heap.Init(&s.expiries)
+	return s
+}
+
+func (s *InMemoryRefreshTokenStore) purgeExpiredLocked(now time.Time) int {
 	var cleaned int
-	for token, data := range s.tokens {
-		if now.After(data.Expiry) {
-			delete(s.tokens, token)
-			cleaned++
+	for s.expiries.Len() > 0 {
+		entry := s.expiries[0]
+		if entry.expiry.After(now) {
+			break
 		}
+		heap.Pop(&s.expiries)
+		current, exists := s.expiryIx[entry.token]
+		if !exists || current != entry {
+			continue
+		}
+		delete(s.expiryIx, entry.token)
+		delete(s.tokens, entry.token)
+		cleaned++
 	}
 	return cleaned
 }
 
-func NewInMemoryRefreshTokenStore() *InMemoryRefreshTokenStore {
-	return &InMemoryRefreshTokenStore{
-		tokens: make(map[string]*core.RefreshTokenData),
+func (s *InMemoryRefreshTokenStore) setLocked(token string, userData any, expiry, created time.Time) {
+	if existing, exists := s.expiryIx[token]; exists {
+		heap.Remove(&s.expiries, existing.index)
+		delete(s.expiryIx, token)
 	}
+	entry := &expiryEntry{token: token, expiry: expiry}
+	heap.Push(&s.expiries, entry)
+	s.expiryIx[token] = entry
+	s.tokens[token] = &core.RefreshTokenData{
+		UserData: userData,
+		Expiry:   expiry,
+		Created:  created,
+	}
+}
+
+func (s *InMemoryRefreshTokenStore) deleteLocked(token string) {
+	if entry, exists := s.expiryIx[token]; exists {
+		heap.Remove(&s.expiries, entry.index)
+		delete(s.expiryIx, token)
+	}
+	delete(s.tokens, token)
 }
 
 func (s *InMemoryRefreshTokenStore) Set(ctx context.Context, token string, userData any, expiry time.Time) error {
 	if token == "" {
 		return errors.New("token cannot be empty")
 	}
+	now := time.Now()
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.cleanupExpiredLocked(time.Now())
-	s.tokens[token] = &core.RefreshTokenData{
-		UserData: userData,
-		Expiry:   expiry,
-		Created:  time.Now(),
-	}
+	s.purgeExpiredLocked(now)
+	s.setLocked(token, userData, expiry, now)
 	return nil
 }
 
@@ -52,15 +122,29 @@ func (s *InMemoryRefreshTokenStore) Get(ctx context.Context, token string) (any,
 	if token == "" {
 		return nil, core.ErrRefreshTokenNotFound
 	}
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.cleanupExpiredLocked(time.Now())
+	now := time.Now()
+	s.mu.RLock()
 	data, exists := s.tokens[token]
 	if !exists {
+		s.mu.RUnlock()
 		return nil, core.ErrRefreshTokenNotFound
 	}
-	if data.IsExpired() {
-		delete(s.tokens, token)
+	if !now.After(data.Expiry) {
+		userData := data.UserData
+		s.mu.RUnlock()
+		return userData, nil
+	}
+	s.mu.RUnlock()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.purgeExpiredLocked(now)
+	data, exists = s.tokens[token]
+	if !exists {
+		return nil, core.ErrRefreshTokenExpired
+	}
+	if now.After(data.Expiry) {
+		s.deleteLocked(token)
 		return nil, core.ErrRefreshTokenExpired
 	}
 	return data.UserData, nil
@@ -70,18 +154,19 @@ func (s *InMemoryRefreshTokenStore) Consume(ctx context.Context, token string) (
 	if token == "" {
 		return nil, core.ErrRefreshTokenNotFound
 	}
+	now := time.Now()
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.cleanupExpiredLocked(time.Now())
+	s.purgeExpiredLocked(now)
 	data, exists := s.tokens[token]
 	if !exists {
 		return nil, core.ErrRefreshTokenNotFound
 	}
-	if data.IsExpired() {
-		delete(s.tokens, token)
+	if now.After(data.Expiry) {
+		s.deleteLocked(token)
 		return nil, core.ErrRefreshTokenExpired
 	}
-	delete(s.tokens, token)
+	s.deleteLocked(token)
 	return data.UserData, nil
 }
 
@@ -95,21 +180,17 @@ func (s *InMemoryRefreshTokenStore) Rotate(ctx context.Context, oldToken, newTok
 	now := time.Now()
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.cleanupExpiredLocked(now)
+	s.purgeExpiredLocked(now)
 	data, exists := s.tokens[oldToken]
 	if !exists {
 		return core.ErrRefreshTokenNotFound
 	}
-	if data.IsExpired() {
-		delete(s.tokens, oldToken)
+	if now.After(data.Expiry) {
+		s.deleteLocked(oldToken)
 		return core.ErrRefreshTokenExpired
 	}
-	s.tokens[newToken] = &core.RefreshTokenData{
-		UserData: userData,
-		Expiry:   expiry,
-		Created:  now,
-	}
-	delete(s.tokens, oldToken)
+	s.setLocked(newToken, userData, expiry, now)
+	s.deleteLocked(oldToken)
 	return nil
 }
 
@@ -119,20 +200,29 @@ func (s *InMemoryRefreshTokenStore) Delete(ctx context.Context, token string) er
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	delete(s.tokens, token)
+	s.deleteLocked(token)
 	return nil
 }
 
 func (s *InMemoryRefreshTokenStore) Cleanup(ctx context.Context) (int, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return s.cleanupExpiredLocked(time.Now()), nil
+	return s.purgeExpiredLocked(time.Now()), nil
 }
 
 func (s *InMemoryRefreshTokenStore) Count(ctx context.Context) (int, error) {
+	now := time.Now()
+	s.mu.RLock()
+	count := len(s.tokens)
+	if s.expiries.Len() == 0 || s.expiries[0].expiry.After(now) {
+		s.mu.RUnlock()
+		return count, nil
+	}
+	s.mu.RUnlock()
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.cleanupExpiredLocked(time.Now())
+	s.purgeExpiredLocked(now)
 	return len(s.tokens), nil
 }
 
@@ -140,4 +230,7 @@ func (s *InMemoryRefreshTokenStore) Clear() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.tokens = make(map[string]*core.RefreshTokenData)
+	s.expiryIx = make(map[string]*expiryEntry)
+	s.expiries = expiryHeap{}
+	heap.Init(&s.expiries)
 }

--- a/store/memory.go
+++ b/store/memory.go
@@ -150,26 +150,6 @@ func (s *InMemoryRefreshTokenStore) Get(ctx context.Context, token string) (any,
 	return data.UserData, nil
 }
 
-func (s *InMemoryRefreshTokenStore) Consume(ctx context.Context, token string) (any, error) {
-	if token == "" {
-		return nil, core.ErrRefreshTokenNotFound
-	}
-	now := time.Now()
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.purgeExpiredLocked(now)
-	data, exists := s.tokens[token]
-	if !exists {
-		return nil, core.ErrRefreshTokenNotFound
-	}
-	if now.After(data.Expiry) {
-		s.deleteLocked(token)
-		return nil, core.ErrRefreshTokenExpired
-	}
-	s.deleteLocked(token)
-	return data.UserData, nil
-}
-
 func (s *InMemoryRefreshTokenStore) Rotate(ctx context.Context, oldToken, newToken string, userData any, expiry time.Time) error {
 	if oldToken == "" {
 		return core.ErrRefreshTokenNotFound
@@ -190,7 +170,9 @@ func (s *InMemoryRefreshTokenStore) Rotate(ctx context.Context, oldToken, newTok
 		return core.ErrRefreshTokenExpired
 	}
 	s.setLocked(newToken, userData, expiry, now)
-	s.deleteLocked(oldToken)
+	if oldToken != newToken {
+		s.deleteLocked(oldToken)
+	}
 	return nil
 }
 

--- a/store/memory.go
+++ b/store/memory.go
@@ -16,6 +16,17 @@ type InMemoryRefreshTokenStore struct {
 	mu     sync.RWMutex
 }
 
+func (s *InMemoryRefreshTokenStore) cleanupExpiredLocked(now time.Time) int {
+	var cleaned int
+	for token, data := range s.tokens {
+		if now.After(data.Expiry) {
+			delete(s.tokens, token)
+			cleaned++
+		}
+	}
+	return cleaned
+}
+
 func NewInMemoryRefreshTokenStore() *InMemoryRefreshTokenStore {
 	return &InMemoryRefreshTokenStore{
 		tokens: make(map[string]*core.RefreshTokenData),
@@ -28,6 +39,7 @@ func (s *InMemoryRefreshTokenStore) Set(ctx context.Context, token string, userD
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	s.cleanupExpiredLocked(time.Now())
 	s.tokens[token] = &core.RefreshTokenData{
 		UserData: userData,
 		Expiry:   expiry,
@@ -40,25 +52,65 @@ func (s *InMemoryRefreshTokenStore) Get(ctx context.Context, token string) (any,
 	if token == "" {
 		return nil, core.ErrRefreshTokenNotFound
 	}
-	s.mu.RLock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.cleanupExpiredLocked(time.Now())
 	data, exists := s.tokens[token]
-	s.mu.RUnlock()
 	if !exists {
 		return nil, core.ErrRefreshTokenNotFound
 	}
 	if data.IsExpired() {
-		s.mu.Lock()
-		// Double-check after acquiring write lock
-		if data, exists := s.tokens[token]; exists && data.IsExpired() {
-			delete(s.tokens, token)
-			s.mu.Unlock()
-			return nil, core.ErrRefreshTokenExpired
-		}
-		s.mu.Unlock()
-		// Token was already deleted or refreshed by another goroutine
-		return nil, core.ErrRefreshTokenNotFound
+		delete(s.tokens, token)
+		return nil, core.ErrRefreshTokenExpired
 	}
 	return data.UserData, nil
+}
+
+func (s *InMemoryRefreshTokenStore) Consume(ctx context.Context, token string) (any, error) {
+	if token == "" {
+		return nil, core.ErrRefreshTokenNotFound
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.cleanupExpiredLocked(time.Now())
+	data, exists := s.tokens[token]
+	if !exists {
+		return nil, core.ErrRefreshTokenNotFound
+	}
+	if data.IsExpired() {
+		delete(s.tokens, token)
+		return nil, core.ErrRefreshTokenExpired
+	}
+	delete(s.tokens, token)
+	return data.UserData, nil
+}
+
+func (s *InMemoryRefreshTokenStore) Rotate(ctx context.Context, oldToken, newToken string, userData any, expiry time.Time) error {
+	if oldToken == "" {
+		return core.ErrRefreshTokenNotFound
+	}
+	if newToken == "" {
+		return errors.New("token cannot be empty")
+	}
+	now := time.Now()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.cleanupExpiredLocked(now)
+	data, exists := s.tokens[oldToken]
+	if !exists {
+		return core.ErrRefreshTokenNotFound
+	}
+	if data.IsExpired() {
+		delete(s.tokens, oldToken)
+		return core.ErrRefreshTokenExpired
+	}
+	s.tokens[newToken] = &core.RefreshTokenData{
+		UserData: userData,
+		Expiry:   expiry,
+		Created:  now,
+	}
+	delete(s.tokens, oldToken)
+	return nil
 }
 
 func (s *InMemoryRefreshTokenStore) Delete(ctx context.Context, token string) error {
@@ -74,20 +126,13 @@ func (s *InMemoryRefreshTokenStore) Delete(ctx context.Context, token string) er
 func (s *InMemoryRefreshTokenStore) Cleanup(ctx context.Context) (int, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	var cleaned int
-	now := time.Now()
-	for token, data := range s.tokens {
-		if now.After(data.Expiry) {
-			delete(s.tokens, token)
-			cleaned++
-		}
-	}
-	return cleaned, nil
+	return s.cleanupExpiredLocked(time.Now()), nil
 }
 
 func (s *InMemoryRefreshTokenStore) Count(ctx context.Context) (int, error) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.cleanupExpiredLocked(time.Now())
 	return len(s.tokens), nil
 }
 


### PR DESCRIPTION
Tighten token parsing defaults so tokens use the expected signing method and required time claims. Rotate refresh tokens safely so transient issuance failures do not burn a valid refresh token, and cover the new behavior with tests and docs.