### PR TITLE
feat: add RefreshTokenRevoker interface for atomic logout

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Touka 的 JWT 中间件。
 - `ExpField`：`exp`
 - `CookieName`：`jwt`
 - `RefreshTokenCookieName`：`refresh_token`
+- 完整的 cookie 配置项请参考 [configuration.md](./docs/configuration.md)
 
 ## Breaking Changes
 
@@ -160,6 +161,16 @@ refresh token 的生命周期还受两个时长共同影响：
 - 每次生成或轮换时，底层 store 中保存的 refresh token 过期时间为 `min(now + RefreshTokenTimeout, MaxRefreshUntil)`
 - 如果设置了 `MaxRefresh`，首次登录时会把绝对上限写入 `RefreshTokenState.MaxRefreshUntil`
 - `RefreshHandler` 返回的新 refresh token 会继承原来的绝对上限，不会因为轮换而无限续期
+
+## Logout Handler
+
+`LogoutHandler` 执行用户登出并撤销 refresh token：
+
+- 从 cookie 或 form 提取当前 refresh token
+- 按进程内记录且仍未过期的 successor 链查找相关 token
+- 若 store 实现 `RefreshTokenRevoker`，调用 `Revoke` 原子撤销整链
+- 否则逐个 `Delete`
+- 若 `SendCookie=true`，清除 access token 和 refresh token cookie
 
 ## Example App
 

--- a/auth_jwt.go
+++ b/auth_jwt.go
@@ -423,9 +423,7 @@ func (mw *ToukaJWTMiddleware) LogoutHandler(c *touka.Context) {
 			mw.unauthorized(c, http.StatusInternalServerError, mw.HTTPStatusMessageFunc(err, c))
 			return
 		}
-		for _, token := range tokens {
-			deleteRefreshTokenSuccessor(token)
-		}
+		deleteRefreshTokenSuccessors(tokens)
 	}
 	if mw.SendCookie {
 		mw.writeCookie(c, mw.CookieName, "", -1, mw.SecureCookie, mw.CookieHTTPOnly)
@@ -886,7 +884,7 @@ func lockRefreshTokenChain(token string, now time.Time) ([]string, func()) {
 		seen[token] = struct{}{}
 		unlockers = append(unlockers, acquireRefreshTokenLock(token))
 		tokens = append(tokens, token)
-		token = nextRefreshToken(token, now)
+		token = logoutSuccessorToken(token)
 	}
 	return tokens, func() {
 		for i := len(unlockers) - 1; i >= 0; i-- {
@@ -921,9 +919,30 @@ func nextRefreshToken(token string, now time.Time) string {
 	return entry.next
 }
 
+func logoutSuccessorToken(token string) string {
+	refreshTokenChainMu.Lock()
+	entry, ok := refreshTokenChain[token]
+	refreshTokenChainMu.Unlock()
+	if !ok {
+		return ""
+	}
+	return entry.next
+}
+
 func deleteRefreshTokenSuccessor(token string) {
 	refreshTokenChainMu.Lock()
 	delete(refreshTokenChain, token)
+	refreshTokenChainMu.Unlock()
+}
+
+func deleteRefreshTokenSuccessors(tokens []string) {
+	if len(tokens) == 0 {
+		return
+	}
+	refreshTokenChainMu.Lock()
+	for _, token := range tokens {
+		delete(refreshTokenChain, token)
+	}
 	refreshTokenChainMu.Unlock()
 }
 

--- a/auth_jwt.go
+++ b/auth_jwt.go
@@ -417,26 +417,14 @@ func (mw *ToukaJWTMiddleware) LoginHandler(c *touka.Context) {
 func (mw *ToukaJWTMiddleware) LogoutHandler(c *touka.Context) {
 	refreshToken := mw.extractRefreshToken(c)
 	if refreshToken != "" {
-		token := refreshToken
-		unlock := acquireRefreshTokenLock(token)
-		for token != "" {
-			next := nextRefreshToken(token, mw.TimeFunc())
-			var nextUnlock func()
-			if next != "" {
-				nextUnlock = acquireRefreshTokenLock(next)
-			}
-			if err := mw.TokenStore.Delete(c.Request.Context(), token); err != nil && !errors.Is(err, core.ErrRefreshTokenNotFound) && !errors.Is(err, core.ErrRefreshTokenExpired) {
-				if nextUnlock != nil {
-					nextUnlock()
-				}
-				unlock()
-				mw.unauthorized(c, http.StatusInternalServerError, mw.HTTPStatusMessageFunc(err, c))
-				return
-			}
+		tokens, unlock := lockRefreshTokenChain(refreshToken, mw.TimeFunc())
+		defer unlock()
+		if err := mw.revokeRefreshTokenChain(c.Request.Context(), tokens); err != nil {
+			mw.unauthorized(c, http.StatusInternalServerError, mw.HTTPStatusMessageFunc(err, c))
+			return
+		}
+		for _, token := range tokens {
 			deleteRefreshTokenSuccessor(token)
-			unlock()
-			unlock = nextUnlock
-			token = next
 		}
 	}
 	if mw.SendCookie {
@@ -476,8 +464,10 @@ func (mw *ToukaJWTMiddleware) RefreshHandler(c *touka.Context) {
 		mw.unauthorized(c, http.StatusInternalServerError, mw.HTTPStatusMessageFunc(err, c))
 		return
 	}
-	mw.setAccessTokenCookie(c, tokenPair.AccessToken, tokenPair.ExpiresAt)
-	mw.SetRefreshTokenCookie(c, tokenPair.RefreshToken, tokenPair.RefreshExpiresAt)
+	if mw.SendCookie {
+		mw.setAccessTokenCookie(c, tokenPair.AccessToken, tokenPair.ExpiresAt)
+		mw.SetRefreshTokenCookie(c, tokenPair.RefreshToken, tokenPair.RefreshExpiresAt)
+	}
 	mw.RefreshResponse(c, http.StatusOK, tokenPair)
 }
 
@@ -552,6 +542,25 @@ func (mw *ToukaJWTMiddleware) rotateRefreshToken(ctx context.Context, oldToken, 
 		return nil
 	}
 	return ErrUnsafeRefreshRotation
+}
+
+func (mw *ToukaJWTMiddleware) revokeRefreshTokenChain(ctx context.Context, tokens []string) error {
+	if len(tokens) == 0 {
+		return nil
+	}
+	if revoker, ok := mw.TokenStore.(core.RefreshTokenRevoker); ok {
+		err := revoker.Revoke(ctx, tokens)
+		if err == nil || errors.Is(err, core.ErrRefreshTokenNotFound) || errors.Is(err, core.ErrRefreshTokenExpired) {
+			return nil
+		}
+		return err
+	}
+	for _, token := range tokens {
+		if err := mw.TokenStore.Delete(ctx, token); err != nil && !errors.Is(err, core.ErrRefreshTokenNotFound) && !errors.Is(err, core.ErrRefreshTokenExpired) {
+			return err
+		}
+	}
+	return nil
 }
 
 func (mw *ToukaJWTMiddleware) generateRefreshToken() (string, error) {
@@ -860,6 +869,29 @@ func acquireRefreshTokenLock(token string) func() {
 			delete(refreshTokenLocks, token)
 		}
 		refreshTokenLocksMu.Unlock()
+	}
+}
+
+func lockRefreshTokenChain(token string, now time.Time) ([]string, func()) {
+	if token == "" {
+		return nil, func() {}
+	}
+	seen := map[string]struct{}{}
+	tokens := []string{}
+	unlockers := []func(){}
+	for token != "" {
+		if _, ok := seen[token]; ok {
+			break
+		}
+		seen[token] = struct{}{}
+		unlockers = append(unlockers, acquireRefreshTokenLock(token))
+		tokens = append(tokens, token)
+		token = nextRefreshToken(token, now)
+	}
+	return tokens, func() {
+		for i := len(unlockers) - 1; i >= 0; i-- {
+			unlockers[i]()
+		}
 	}
 }
 

--- a/auth_jwt.go
+++ b/auth_jwt.go
@@ -884,7 +884,9 @@ func lockRefreshTokenChain(token string, now time.Time) ([]string, func()) {
 		seen[token] = struct{}{}
 		unlockers = append(unlockers, acquireRefreshTokenLock(token))
 		tokens = append(tokens, token)
-		token = logoutSuccessorToken(token)
+		// Expired successor edges terminate logout traversal so a stale ancestor
+		// token cannot keep revoking newer sessions after its own expiry window.
+		token = nextRefreshToken(token, now)
 	}
 	return tokens, func() {
 		for i := len(unlockers) - 1; i >= 0; i-- {
@@ -917,22 +919,6 @@ func nextRefreshToken(token string, now time.Time) string {
 		return ""
 	}
 	return entry.next
-}
-
-func logoutSuccessorToken(token string) string {
-	refreshTokenChainMu.Lock()
-	entry, ok := refreshTokenChain[token]
-	refreshTokenChainMu.Unlock()
-	if !ok {
-		return ""
-	}
-	return entry.next
-}
-
-func deleteRefreshTokenSuccessor(token string) {
-	refreshTokenChainMu.Lock()
-	delete(refreshTokenChain, token)
-	refreshTokenChainMu.Unlock()
 }
 
 func deleteRefreshTokenSuccessors(tokens []string) {

--- a/auth_jwt_test.go
+++ b/auth_jwt_test.go
@@ -991,6 +991,43 @@ func TestLogoutHandlerUsesAtomicRevokeWhenAvailable(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 }
 
+func TestLogoutHandlerRevokesKnownSuccessorsPastExpiredLink(t *testing.T) {
+	auth, err := New(&ToukaJWTMiddleware{
+		Realm: "test",
+		Key:   testPrivateKey(t),
+	})
+	require.NoError(t, err)
+
+	store := &recordingRevokerStore{tokens: map[string]any{
+		"r1": "admin",
+		"r2": "admin",
+		"r3": "admin",
+	}}
+	auth.TokenStore = store
+
+	now := time.Now()
+	setRefreshTokenSuccessor("r1", "r2", now.Add(-time.Second), now)
+	setRefreshTokenSuccessor("r2", "r3", now.Add(time.Minute), now)
+
+	w := httptest.NewRecorder()
+	c, _ := touka.CreateTestContext(w)
+	form := strings.NewReader("refresh_token=r1")
+	req := httptest.NewRequest(http.MethodPost, "/logout", form)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	c.Request = req
+
+	auth.LogoutHandler(c)
+
+	assert.Len(t, store.revokeCalls, 1)
+	assert.Equal(t, []string{"r1", "r2", "r3"}, store.revokeCalls[0].tokens)
+	for _, token := range []string{"r1", "r2", "r3"} {
+		_, err := store.Get(context.Background(), token)
+		assert.ErrorIs(t, err, core.ErrRefreshTokenNotFound)
+		assert.Equal(t, "", logoutSuccessorToken(token))
+	}
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
 func TestLogoutHandlerKeepsIdempotentBehaviorForAtomicRevoke(t *testing.T) {
 	auth, err := New(&ToukaJWTMiddleware{
 		Realm: "test",

--- a/auth_jwt_test.go
+++ b/auth_jwt_test.go
@@ -991,7 +991,7 @@ func TestLogoutHandlerUsesAtomicRevokeWhenAvailable(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 }
 
-func TestLogoutHandlerRevokesKnownSuccessorsPastExpiredLink(t *testing.T) {
+func TestLogoutHandlerStopsAtExpiredSuccessorLink(t *testing.T) {
 	auth, err := New(&ToukaJWTMiddleware{
 		Realm: "test",
 		Key:   testPrivateKey(t),
@@ -1019,12 +1019,15 @@ func TestLogoutHandlerRevokesKnownSuccessorsPastExpiredLink(t *testing.T) {
 	auth.LogoutHandler(c)
 
 	assert.Len(t, store.revokeCalls, 1)
-	assert.Equal(t, []string{"r1", "r2", "r3"}, store.revokeCalls[0].tokens)
-	for _, token := range []string{"r1", "r2", "r3"} {
-		_, err := store.Get(context.Background(), token)
-		assert.ErrorIs(t, err, core.ErrRefreshTokenNotFound)
-		assert.Equal(t, "", logoutSuccessorToken(token))
-	}
+	assert.Equal(t, []string{"r1"}, store.revokeCalls[0].tokens)
+	_, err = store.Get(context.Background(), "r1")
+	assert.ErrorIs(t, err, core.ErrRefreshTokenNotFound)
+	_, err = store.Get(context.Background(), "r2")
+	assert.NoError(t, err)
+	_, err = store.Get(context.Background(), "r3")
+	assert.NoError(t, err)
+	assert.Equal(t, "", nextRefreshToken("r1", now))
+	assert.Equal(t, "r3", nextRefreshToken("r2", now))
 	assert.Equal(t, http.StatusOK, w.Code)
 }
 

--- a/auth_jwt_test.go
+++ b/auth_jwt_test.go
@@ -903,6 +903,120 @@ func (r *recordingRotatorStore) Count(ctx context.Context) (int, error) {
 	return len(r.tokens), nil
 }
 
+type revokeCall struct {
+	tokens []string
+}
+
+type recordingRevokerStore struct {
+	tokens      map[string]any
+	revokeCalls []revokeCall
+	deleteCalls []string
+	revokeErr   error
+}
+
+func (r *recordingRevokerStore) Set(ctx context.Context, token string, userData any, expiry time.Time) error {
+	r.tokens[token] = userData
+	return nil
+}
+
+func (r *recordingRevokerStore) Get(ctx context.Context, token string) (any, error) {
+	data, ok := r.tokens[token]
+	if !ok {
+		return nil, core.ErrRefreshTokenNotFound
+	}
+	return data, nil
+}
+
+func (r *recordingRevokerStore) Delete(ctx context.Context, token string) error {
+	r.deleteCalls = append(r.deleteCalls, token)
+	delete(r.tokens, token)
+	return nil
+}
+
+func (r *recordingRevokerStore) Revoke(ctx context.Context, tokens []string) error {
+	cloned := append([]string(nil), tokens...)
+	r.revokeCalls = append(r.revokeCalls, revokeCall{tokens: cloned})
+	if r.revokeErr != nil {
+		return r.revokeErr
+	}
+	for _, token := range tokens {
+		delete(r.tokens, token)
+	}
+	return nil
+}
+
+func (r *recordingRevokerStore) Cleanup(ctx context.Context) (int, error) {
+	return 0, nil
+}
+
+func (r *recordingRevokerStore) Count(ctx context.Context) (int, error) {
+	return len(r.tokens), nil
+}
+
+func TestLogoutHandlerUsesAtomicRevokeWhenAvailable(t *testing.T) {
+	auth, err := New(&ToukaJWTMiddleware{
+		Realm: "test",
+		Key:   testPrivateKey(t),
+	})
+	require.NoError(t, err)
+
+	store := &recordingRevokerStore{tokens: map[string]any{
+		"r1": "admin",
+		"r2": "admin",
+		"r3": "admin",
+	}}
+	auth.TokenStore = store
+
+	now := time.Now()
+	setRefreshTokenSuccessor("r1", "r2", now.Add(time.Minute), now)
+	setRefreshTokenSuccessor("r2", "r3", now.Add(time.Minute), now)
+
+	w := httptest.NewRecorder()
+	c, _ := touka.CreateTestContext(w)
+	form := strings.NewReader("refresh_token=r1")
+	req := httptest.NewRequest(http.MethodPost, "/logout", form)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	c.Request = req
+
+	auth.LogoutHandler(c)
+
+	assert.Len(t, store.revokeCalls, 1)
+	assert.Equal(t, []string{"r1", "r2", "r3"}, store.revokeCalls[0].tokens)
+	assert.Empty(t, store.deleteCalls)
+	for _, token := range []string{"r1", "r2", "r3"} {
+		_, err := store.Get(context.Background(), token)
+		assert.ErrorIs(t, err, core.ErrRefreshTokenNotFound)
+		assert.Equal(t, "", nextRefreshToken(token, time.Now()))
+	}
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestLogoutHandlerKeepsIdempotentBehaviorForAtomicRevoke(t *testing.T) {
+	auth, err := New(&ToukaJWTMiddleware{
+		Realm: "test",
+		Key:   testPrivateKey(t),
+	})
+	require.NoError(t, err)
+
+	store := &recordingRevokerStore{
+		tokens:    map[string]any{"r1": "admin"},
+		revokeErr: core.ErrRefreshTokenNotFound,
+	}
+	auth.TokenStore = store
+
+	w := httptest.NewRecorder()
+	c, _ := touka.CreateTestContext(w)
+	form := strings.NewReader("refresh_token=r1")
+	req := httptest.NewRequest(http.MethodPost, "/logout", form)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	c.Request = req
+
+	auth.LogoutHandler(c)
+
+	assert.Len(t, store.revokeCalls, 1)
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
 func toukaHandlerForAlgorithm(auth *ToukaJWTMiddleware) *touka.Engine {
 	r := touka.New()
 	r.POST("/login", auth.LoginHandler)

--- a/core/store.go
+++ b/core/store.go
@@ -40,6 +40,21 @@ type RefreshTokenRotator interface {
 	Rotate(ctx context.Context, oldToken, newToken string, userData any, expiry time.Time) error
 }
 
+// RefreshTokenRevoker atomically revokes one or more refresh tokens.
+// Stores that implement this can avoid partial logout state when a logout
+// request needs to invalidate a known successor chain.
+//
+// Revoke must apply to the full batch atomically: on success, every token in
+// the provided slice is no longer usable. Implementations should also keep the
+// operation idempotent for logout semantics. If Revoke returns
+// ErrRefreshTokenNotFound or ErrRefreshTokenExpired, callers assume every token
+// in the batch is already absent or unusable and may clear any in-memory logout
+// bookkeeping for the whole chain.
+type RefreshTokenRevoker interface {
+	TokenStore
+	Revoke(ctx context.Context, tokens []string) error
+}
+
 // RefreshTokenData holds the data stored with each refresh token
 type RefreshTokenData struct {
 	UserData any       `json:"user_data"`

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,7 +21,7 @@ Touka 框架的 JWT 中间件，移植自 [appleboy/gin-jwt](https://github.com/
 | Refresh Token 存储 | 默认使用内存存储 `InMemoryRefreshTokenStore`；可替换为自定义 `TokenStore` |
 | Refresh Token 状态 | 配置 `MaxRefresh` 时，store 中保存 `RefreshTokenState{user_data, max_refresh_until}`；未配置时直接保存用户数据 |
 | Token 轮换 | `RefreshHandler` 会生成新的 refresh token，并要求 store 实现 `RefreshTokenRotator` 做原子轮换；默认内存 store 已实现 |
-| Logout 行为 | `LogoutHandler` 会删除当前 refresh token；若该 token 已在本进程内被轮换，还会继续删除已记录的后继 token 链 |
+| Logout 行为 | `LogoutHandler` 会删除当前 refresh token；若该 token 已在本进程内被轮换，还会继续删除已记录且未过期的后继 token 链 |
 
 ## 默认值
 
@@ -54,22 +54,29 @@ Touka 框架的 JWT 中间件，移植自 [appleboy/gin-jwt](https://github.com/
 ## 快速开始
 
 ```go
-seed := make([]byte, mldsa.MLDSA65().SeedSize())
-if _, err := io.ReadFull(rand.Reader, seed); err != nil {
-    panic(err)
+import (
+	"filippo.io/mldsa"
+	jwtmw "github.com/fenthope/jwt"
+	"github.com/infinite-iroha/touka"
+	"time"
+)
+
+privateKey, err := mldsa.GenerateKey(mldsa.MLDSA65())
+if err != nil {
+	panic(err)
 }
 
 mw := &jwtmw.ToukaJWTMiddleware{
-    Realm: "test zone",
-    PrivKeyBytes: seed,
-    Timeout: time.Hour,
-    MaxRefresh: 7 * 24 * time.Hour,
-    Authenticator: func(c *touka.Context) (any, error) {
-        return "admin", nil
-    },
-    PayloadFunc: func(data any) jwtmw.MapClaims {
-        return jwtmw.MapClaims{"identity": data}
-    },
+	Realm: "test zone",
+	Key: privateKey,
+	Timeout: time.Hour,
+	MaxRefresh: 7 * 24 * time.Hour,
+	Authenticator: func(c *touka.Context) (any, error) {
+		return "admin", nil
+	},
+	PayloadFunc: func(data any) jwtmw.MapClaims {
+		return jwtmw.MapClaims{"identity": data}
+	},
 }
 ```
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -112,10 +112,17 @@ type TokenStore interface {
 }
 
 type RefreshTokenRotator interface {
-    TokenStore
-    Rotate(ctx context.Context, oldToken, newToken string, userData any, expiry time.Time) error
+	TokenStore
+	Rotate(ctx context.Context, oldToken, newToken string, userData any, expiry time.Time) error
+}
+
+type RefreshTokenRevoker interface {
+	TokenStore
+	Revoke(ctx context.Context, tokens []string) error
 }
 ```
+
+实现此接口的 store 可以让 LogoutHandler 原子性地撤销整条 refresh token 链。
 
 `TokenStore` 用于持久化 refresh token 及其关联的 `userData`。默认实现是内存 store：`store.NewInMemoryRefreshTokenStoreWithClock(mw.TimeFunc)`。
 
@@ -165,7 +172,7 @@ func (mw *ToukaJWTMiddleware) LoginHandler(c *touka.Context)
 ### 内部流程
 
 1. 调用 `Authenticator(c)` 验证用户凭据
-2. 若认证失败，调用 `unauthorized` 返回 401，并设置 `WWW-Authenticate` 响应头；当 `DisabledAbort` 为 `false` 时会先 `Abort`
+2. 若认证失败，调用 `unauthorized` 返回 401，**始终**设置 `WWW-Authenticate` 响应头；当 `DisabledAbort` 为 `false` 时会先 `Abort`
 3. 调用 `TokenGenerator` 生成 token pair
 4. 调用 `setAccessTokenCookie` 设置 access token cookie（内部检查 `SendCookie`，仅在 `SendCookie=true` 时写入）
 5. 调用 `SetRefreshTokenCookie` 设置 refresh token cookie（内部检查 `SendCookie`，仅在 `SendCookie=true` 时写入）
@@ -337,7 +344,7 @@ func (mw *ToukaJWTMiddleware) LogoutHandler(c *touka.Context)
 ### 内部流程
 
 1. 按顺序从 cookie 或 form body 提取 refresh token
-2. 若找到 refresh token，按当前进程内记录的 successor 链继续查找后继 refresh token，并从 `TokenStore` 中删除这些相关 token
+2. 若找到 refresh token，按当前进程内记录且仍未过期的 successor 链获取可撤销链。若 store 实现 RefreshTokenRevoker 接口，调用 Revoke 原子撤销整链；否则逐个 Delete
 3. 删除过程中会忽略 `core.ErrRefreshTokenNotFound` 和 `core.ErrRefreshTokenExpired`
 4. 若删除出现其他错误，返回 500
 5. 若 `SendCookie` 为 true，清除 `CookieName` 和 `RefreshTokenCookieName` 对应的 cookie
@@ -349,7 +356,7 @@ func (mw *ToukaJWTMiddleware) LogoutHandler(c *touka.Context)
 engine.POST("/logout", auth.LogoutHandler)
 ```
 
-注意：`LogoutHandler` 会基于当前进程内记录的 refresh token successor 链删除相关 token，同时清除客户端 cookie。该链不是持久化状态，也不是跨实例共享状态；如果只想清除 cookie 而不撤销 token，可以在调用 `LogoutHandler` 之前自行处理。
+注意：`LogoutHandler` 会基于当前进程内记录的 refresh token successor 链删除相关 token，同时清除客户端 cookie。logout 只会沿仍未过期的 successor 映射继续追链；过期映射会被视为链路中断。该链不是持久化状态，也不是跨实例共享状态；如果只想清除 cookie 而不撤销 token，可以在调用 `LogoutHandler` 之前自行处理。
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -71,9 +71,9 @@
 
 验签公钥加载优先级：
 
-1. `PubKeyBytes`
-2. `PubKeyFile`
-3. 从 `Key` 派生公钥
+1. `PubKeyFile`（有文件路径时从文件加载，会覆盖 PubKeyBytes）
+2. `PubKeyBytes`（仅有字节数组时使用）
+3. 从 `Key` 派生公钥（当前两项都缺失时）
 
 若使用公钥验签模式（Verify-Only），只需提供 `PubKeyBytes` 或 `PubKeyFile`，此时 `LoginHandler` 和 `RefreshHandler` 会因缺少私钥而失败。
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -172,7 +172,7 @@ curl http://localhost:8000/auth/hello \
 
 ## 2. Verify-Only Mode
 
-如果服务只负责验证 token、不负责签发，可以使用 Verify-Only 模式。此时只提供公钥，不配置私钥，因此不能调用 `LoginHandler` 和 `RefreshHandler`。
+如果服务只负责验证 token、不负责签发，可以使用 Verify-Only 模式。此时只提供公钥（通过 PubKeyBytes 或 PubKeyFile），不配置私钥（Key 为 nil），因此不能调用 `LoginHandler` 和 `RefreshHandler`。
 
 ```go
 package main
@@ -188,7 +188,7 @@ import (
 )
 
 func main() {
-    // 这里假设公钥已经持久化并从配置或文件中读出。
+    // 这里假设公钥已经从配置或文件中加载，并设置到 PubKeyBytes
     privateKey, err := mldsa.GenerateKey(mldsa.MLDSA65())
     if err != nil {
         log.Fatal(err)

--- a/docs/security.md
+++ b/docs/security.md
@@ -162,11 +162,14 @@ func (mw *ToukaJWTMiddleware) rotateRefreshToken(ctx context.Context, oldToken, 
 
 当前实现不仅在 refresh 时加锁，还维护了一个进程内 successor 链：旧 refresh token 轮换成功后，会记录 `old -> new` 映射；`LogoutHandler` 会从当前 refresh token 开始，沿着这条链删除后继 token，尽量覆盖同一进程内发生过的连续轮换。
 
+当底层 store 实现 `core.RefreshTokenRevoker` 时，middleware 会把整条已知链作为一个批次交给 `Revoke`。该接口的契约是：要么整批 token 一次性失效，要么返回错误；并且 logout 语义要求该操作对“已不存在/已过期”的 token 保持幂等。也就是说，`Revoke` 若返回 `ErrRefreshTokenNotFound` 或 `ErrRefreshTokenExpired`，应表示这一批 token 已经整体不可用，而不是只表示其中某一个 token 删除失败。
+
 这带来以下安全语义：
 
 - 同进程并发 refresh：`oldToken` 上的互斥锁能序列化 `rotateRefreshToken`
 - refresh 时的 `MaxRefreshUntil` 会在进入 handler 后校验一次，在持锁轮换时再校验一次，避免并发窗口绕过过期判断
 - logout 只会沿着当前进程内记住的 successor 链继续删除；如果链信息不存在，logout 只删除当前提交上来的 refresh token
+- 实现了 `RefreshTokenRevoker` 的 store 可以把“当前 token 以及已知 successor 链的删除”下推为一次原子撤销；若未实现，则 middleware 退回逐个 `Delete`
 - successor 链仅用于后续 logout 清理，不参与 refresh 鉴权；真正决定 refresh 是否成功的仍是 store 中旧 token 的存在性、过期时间和 `MaxRefreshUntil`
 
 ### 2.5 多实例与非原子轮换风险

--- a/docs/security.md
+++ b/docs/security.md
@@ -169,7 +169,7 @@ func (mw *ToukaJWTMiddleware) rotateRefreshToken(ctx context.Context, oldToken, 
 - 同进程并发 refresh：`oldToken` 上的互斥锁能序列化 `rotateRefreshToken`
 - refresh 时的 `MaxRefreshUntil` 会在进入 handler 后校验一次，在持锁轮换时再校验一次，避免并发窗口绕过过期判断
 - logout 只会沿着当前进程内记住的 successor 链继续删除；如果链信息不存在，logout 只删除当前提交上来的 refresh token
-- logout 遍历已知 successor 链时，不会因为链中某个中间映射已过期就提前停止；只要该映射仍在当前进程内存中，后继 token 仍会继续参与撤销
+- logout 只会沿着当前进程内仍然存在且未过期的 successor 映射继续删除；过期映射会被视为链路中断并在读取时惰性清理
 - 实现了 `RefreshTokenRevoker` 的 store 可以把“当前 token 以及已知 successor 链的删除”下推为一次原子撤销；若未实现，则 middleware 退回逐个 `Delete`
 - successor 链仅用于后续 logout 清理，不参与 refresh 鉴权；真正决定 refresh 是否成功的仍是 store 中旧 token 的存在性、过期时间和 `MaxRefreshUntil`
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -169,6 +169,7 @@ func (mw *ToukaJWTMiddleware) rotateRefreshToken(ctx context.Context, oldToken, 
 - 同进程并发 refresh：`oldToken` 上的互斥锁能序列化 `rotateRefreshToken`
 - refresh 时的 `MaxRefreshUntil` 会在进入 handler 后校验一次，在持锁轮换时再校验一次，避免并发窗口绕过过期判断
 - logout 只会沿着当前进程内记住的 successor 链继续删除；如果链信息不存在，logout 只删除当前提交上来的 refresh token
+- logout 遍历已知 successor 链时，不会因为链中某个中间映射已过期就提前停止；只要该映射仍在当前进程内存中，后继 token 仍会继续参与撤销
 - 实现了 `RefreshTokenRevoker` 的 store 可以把“当前 token 以及已知 successor 链的删除”下推为一次原子撤销；若未实现，则 middleware 退回逐个 `Delete`
 - successor 链仅用于后续 logout 清理，不参与 refresh 鉴权；真正决定 refresh 是否成功的仍是 store 中旧 token 的存在性、过期时间和 `MaxRefreshUntil`
 

--- a/store/memory.go
+++ b/store/memory.go
@@ -11,6 +11,7 @@ import (
 
 var _ core.TokenStore = &InMemoryRefreshTokenStore{}
 var _ core.RefreshTokenRotator = &InMemoryRefreshTokenStore{}
+var _ core.RefreshTokenRevoker = &InMemoryRefreshTokenStore{}
 
 type InMemoryRefreshTokenStore struct {
 	tokens  map[string]*core.RefreshTokenData
@@ -103,6 +104,21 @@ func (s *InMemoryRefreshTokenStore) Rotate(ctx context.Context, oldToken, newTok
 		UserData: userData,
 		Expiry:   expiry,
 		Created:  s.nowFunc(),
+	}
+	return nil
+}
+
+func (s *InMemoryRefreshTokenStore) Revoke(ctx context.Context, tokens []string) error {
+	if len(tokens) == 0 {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, token := range tokens {
+		if token == "" {
+			continue
+		}
+		delete(s.tokens, token)
 	}
 	return nil
 }


### PR DESCRIPTION
- Add RefreshTokenRevoker interface in core/store.go for stores to implement
- LogoutHandler now uses Revoke when available, falling back to per-token Delete
- InMemoryRefreshTokenStore implements Revoke for atomic batch deletion
- Add tests for atomic revoke behavior and idempotency
- Update security documentation